### PR TITLE
Updated daemonset.tf, new versions for node-driver-registrar

### DIFF
--- a/daemonset.tf
+++ b/daemonset.tf
@@ -45,7 +45,11 @@ resource "kubernetes_daemonset" "efs" {
 
         container {
           name              = "efs-plugin"
-          image             = "amazon/aws-efs-csi-driver:v1.3.8"
+          name  = "csi-driver-registrar"
+          # https://gallery.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar depends on the K8s version and minor updates
+          image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-20-19"
+          #image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.1.0-eks-1-18-16"
+          args  = ["--csi-address=$(ADDRESS)", "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)", "--v=${var.log_level}"]
           image_pull_policy = "IfNotPresent"
 
           args = ["--endpoint=$(CSI_ENDPOINT)", "--logtostderr", "--v=${tostring(var.log_level)}"]


### PR DESCRIPTION
1. new versions for node-driver-registrar and URL to check manually
2. Use log_level for verbosity